### PR TITLE
Add proxy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # YouTube Transcript/Subtitle API (including automatically generated subtitles)
 
-[![Build Status](https://travis-ci.org/jdepoix/youtube-transcript-api.svg)](https://travis-ci.org/jdepoix/youtube-transcript-api)
-[![Coverage Status](https://coveralls.io/repos/github/jdepoix/youtube-transcript-api/badge.svg?branch=master)](https://coveralls.io/github/jdepoix/youtube-transcript-api?branch=master)
-[![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](http://opensource.org/licenses/MIT)
-[![image](https://img.shields.io/pypi/v/youtube-transcript-api.svg)](https://pypi.org/project/youtube-transcript-api/)
-[![image](https://img.shields.io/pypi/pyversions/youtube-transcript-api.svg)](https://pypi.org/project/youtube-transcript-api/)
-
 This is an python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles and it does not require a headless browser, like other selenium based solutions do!
 
 ## Install
@@ -89,6 +83,25 @@ If you would prefer to write it into a file or pipe it into another application,
 ```
 youtube_transcript_api <first_video_id> <second_video_id> ... --languages de en --json > transcripts.json
 ```
+
+### Proxy
+
+You can pass a proxy to use during the network requests
+
+Code:
+```python
+from youtube_transcript_api import YouTubeTranscriptApi
+
+YouTubeTranscriptApi.get_transcript(video_id, proxy={"http": "http://user:pass@domain:port", "https": "https://user:pass@domain:port"})
+
+```
+
+CLI:
+```
+youtube_transcript_api <first_video_id> <second_video_id> --http-proxy http://user:pass@domain:port --https-proxy https://user:pass@domain:port
+```
+
+Find out more about using proxies and the type of proxies you can use here: http://docs.python-requests.org/en/master/user/advanced/#proxies
 
 ## Warning
 

--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -14,7 +14,9 @@ class YouTubeTranscriptCli():
     def run(self):
         parsed_args = self._parse_args()
 
-        proxies = {"http": parsed_args.http_proxy, "https": parsed_args.https_proxy}
+        proxies = None
+        if parsed_args.http_proxy != '' or parsed_args.https_proxy != '':
+            proxies = {"http": parsed_args.http_proxy, "https": parsed_args.https_proxy}
 
         transcripts, _ = YouTubeTranscriptApi.get_transcripts(
             parsed_args.video_ids,

--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -14,10 +14,13 @@ class YouTubeTranscriptCli():
     def run(self):
         parsed_args = self._parse_args()
 
+        proxies = {"http": parsed_args.http_proxy, "https": parsed_args.https_proxy}
+
         transcripts, _ = YouTubeTranscriptApi.get_transcripts(
             parsed_args.video_ids,
             languages=parsed_args.languages,
-            continue_after_error=True
+            continue_after_error=True,
+            proxies=proxies
         )
 
         if parsed_args.json:
@@ -52,6 +55,16 @@ class YouTubeTranscriptCli():
             const=True,
             default=False,
             help='If this flag is set the output will be JSON formatted.',
+        )
+        parser.add_argument(
+            '--http-proxy', dest='http_proxy',
+            default='', metavar='URL',
+            help='Use the specified HTTP proxy.'
+        )
+        parser.add_argument(
+            '--https-proxy', dest='https_proxy',
+            default='', metavar='URL',
+            help='Use the specified HTTPS proxy.'
         )
 
         return parser.parse_args(self._args)

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -5,7 +5,7 @@ import os
 
 import httpretty
 
-from youtube_transcript_api._api import YouTubeTranscriptApi, _TranscriptFetcher
+from youtube_transcript_api._api import YouTubeTranscriptApi
 
 
 def load_asset(filename):

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -82,8 +82,8 @@ class TestYouTubeTranscriptApi(TestCase):
 
         YouTubeTranscriptApi.get_transcripts([video_id_1, video_id_2], languages=languages)
 
-        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_1, languages)
-        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_2, languages)
+        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_1, languages, None)
+        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_2, languages, None)
         self.assertEqual(YouTubeTranscriptApi.get_transcript.call_count, 2)
 
     def test_get_transcripts__stop_on_error(self):
@@ -99,5 +99,19 @@ class TestYouTubeTranscriptApi(TestCase):
 
         YouTubeTranscriptApi.get_transcripts(['video_id_1', 'video_id_2'], continue_after_error=True)
 
-        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_1, None)
-        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_2, None)
+        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_1, None, None)
+        YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_2, None, None)
+
+    def test_get_transcript__with_proxies(self):
+        transcript = YouTubeTranscriptApi.get_transcript(
+            'GJLlxj_dtq8', proxies={'http': '', 'https:': ''}
+        )
+
+        self.assertEqual(
+            transcript,
+            [
+                {'text': 'Hey, this is just a test', 'start': 0.0, 'duration': 1.54},
+                {'text': 'this is not the original transcript', 'start': 1.54, 'duration': 4.16},
+                {'text': 'just something shorter, I made up for testing', 'start': 5.7, 'duration': 3.239}
+            ]
+        )

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -5,7 +5,7 @@ import os
 
 import httpretty
 
-from youtube_transcript_api._api import YouTubeTranscriptApi
+from youtube_transcript_api._api import YouTubeTranscriptApi, _TranscriptFetcher
 
 
 def load_asset(filename):
@@ -103,8 +103,9 @@ class TestYouTubeTranscriptApi(TestCase):
         YouTubeTranscriptApi.get_transcript.assert_any_call(video_id_2, None, None)
 
     def test_get_transcript__with_proxies(self):
+        proxies = {'http': '', 'https:': ''}
         transcript = YouTubeTranscriptApi.get_transcript(
-            'GJLlxj_dtq8', proxies={'http': '', 'https:': ''}
+            'GJLlxj_dtq8', proxies=proxies
         )
 
         self.assertEqual(
@@ -115,3 +116,6 @@ class TestYouTubeTranscriptApi(TestCase):
                 {'text': 'just something shorter, I made up for testing', 'start': 5.7, 'duration': 3.239}
             ]
         )
+        YouTubeTranscriptApi.get_transcript = MagicMock()
+        YouTubeTranscriptApi.get_transcripts(['GJLlxj_dtq8'], proxies=proxies)
+        YouTubeTranscriptApi.get_transcript.assert_any_call('GJLlxj_dtq8', None, proxies)

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -12,16 +12,22 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, '')
+        self.assertEqual(parsed_args.https_proxy, '')
 
         parsed_args = YouTubeTranscriptCli('v1 v2 --languages de en --json'.split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, '')
+        self.assertEqual(parsed_args.https_proxy, '')
 
         parsed_args = YouTubeTranscriptCli(' --json v1 v2 --languages de en'.split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, '')
+        self.assertEqual(parsed_args.https_proxy, '')
 
         parsed_args = YouTubeTranscriptCli(
             'v1 v2 --languages de en --json --http-proxy http://user:pass@domain:port --https-proxy https://user:pass@domain:port'.split()
@@ -49,15 +55,6 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.languages, ['de', 'en'])
         self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
         self.assertEqual(parsed_args.http_proxy, '')
-
-        parsed_args = YouTubeTranscriptCli(
-            'v1 v2 --languages de en --json'.split()
-        )._parse_args()
-        self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
-        self.assertEqual(parsed_args.json, True)
-        self.assertEqual(parsed_args.languages, ['de', 'en'])
-        self.assertEqual(parsed_args.http_proxy, '')
-        self.assertEqual(parsed_args.https_proxy, '')
 
     def test_argument_parsing__only_video_ids(self):
         parsed_args = YouTubeTranscriptCli('v1 v2'.split())._parse_args()
@@ -126,3 +123,15 @@ class TestYouTubeTranscriptCli(TestCase):
 
         # will fail if output is not valid json
         json.loads(output)
+
+    def test_run__proxies(self):
+        YouTubeTranscriptApi.get_transcripts = MagicMock(return_value=([], []))
+        YouTubeTranscriptCli(
+            'v1 v2 --languages de en --http-proxy http://user:pass@domain:port --https-proxy https://user:pass@domain:port'.split()).run()
+
+        YouTubeTranscriptApi.get_transcripts.assert_called_once_with(
+            ['v1', 'v2'],
+            languages=['de', 'en'],
+            continue_after_error=True,
+            proxies={'http': 'http://user:pass@domain:port', 'https': 'https://user:pass@domain:port'}
+        )

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -23,6 +23,31 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
 
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --languages de en --json --http-proxy http://user:pass@domain:port --https-proxy https://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
+        self.assertEqual(parsed_args.json, True)
+        self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, 'http://user:pass@domain:port')
+        self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --languages de en --json --http-proxy http://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
+        self.assertEqual(parsed_args.json, True)
+        self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, 'http://user:pass@domain:port')
+
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --languages de en --json --https-proxy https://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
+        self.assertEqual(parsed_args.json, True)
+        self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+
     def test_argument_parsing__only_video_ids(self):
         parsed_args = YouTubeTranscriptCli('v1 v2'.split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
@@ -50,6 +75,17 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.json, False)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
 
+    def test_argument_parsing__proxies(self):
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --http-proxy http://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.http_proxy, 'http://user:pass@domain:port')
+
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --https-proxy https://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+
     def test_run(self):
         YouTubeTranscriptApi.get_transcripts = MagicMock(return_value=([], []))
         YouTubeTranscriptCli('v1 v2 --languages de en'.split()).run()
@@ -57,7 +93,8 @@ class TestYouTubeTranscriptCli(TestCase):
         YouTubeTranscriptApi.get_transcripts.assert_called_once_with(
             ['v1', 'v2'],
             languages=['de', 'en'],
-            continue_after_error=True
+            continue_after_error=True,
+            proxies={"http": "", "https": ""}
         )
 
     def test_run__json_output(self):

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -39,6 +39,7 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
         self.assertEqual(parsed_args.http_proxy, 'http://user:pass@domain:port')
+        self.assertEqual(parsed_args.https_proxy, '')
 
         parsed_args = YouTubeTranscriptCli(
             'v1 v2 --languages de en --json --https-proxy https://user:pass@domain:port'.split()
@@ -47,6 +48,7 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.json, True)
         self.assertEqual(parsed_args.languages, ['de', 'en'])
         self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+        self.assertEqual(parsed_args.http_proxy, '')
 
     def test_argument_parsing__only_video_ids(self):
         parsed_args = YouTubeTranscriptCli('v1 v2'.split())._parse_args()
@@ -94,7 +96,7 @@ class TestYouTubeTranscriptCli(TestCase):
             ['v1', 'v2'],
             languages=['de', 'en'],
             continue_after_error=True,
-            proxies={"http": "", "https": ""}
+            proxies=None
         )
 
     def test_run__json_output(self):

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -50,6 +50,15 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
         self.assertEqual(parsed_args.http_proxy, '')
 
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --languages de en --json'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
+        self.assertEqual(parsed_args.json, True)
+        self.assertEqual(parsed_args.languages, ['de', 'en'])
+        self.assertEqual(parsed_args.http_proxy, '')
+        self.assertEqual(parsed_args.https_proxy, '')
+
     def test_argument_parsing__only_video_ids(self):
         parsed_args = YouTubeTranscriptCli('v1 v2'.split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ['v1', 'v2'])
@@ -87,6 +96,18 @@ class TestYouTubeTranscriptCli(TestCase):
             'v1 v2 --https-proxy https://user:pass@domain:port'.split()
         )._parse_args()
         self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2 --http-proxy http://user:pass@domain:port --https-proxy https://user:pass@domain:port'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.http_proxy, 'http://user:pass@domain:port')
+        self.assertEqual(parsed_args.https_proxy, 'https://user:pass@domain:port')
+
+        parsed_args = YouTubeTranscriptCli(
+            'v1 v2'.split()
+        )._parse_args()
+        self.assertEqual(parsed_args.http_proxy, '')
+        self.assertEqual(parsed_args.https_proxy, '')
 
     def test_run(self):
         YouTubeTranscriptApi.get_transcripts = MagicMock(return_value=([], []))


### PR DESCRIPTION
This will allow you to pass in a proxy to mask your requests.

In the CLI you pass in the raw url for the proxy

In code you can pass in the dict for the proxy:
```
{"http": "http://user:pass@domain:port", "https": "https://user:pass@domain:port"}
```
