### PR TITLE
Bugfix/Issue 83 UnicodeDecodeError for Windows

### DIFF
--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -21,7 +21,10 @@ from youtube_transcript_api import (
 
 
 def load_asset(filename):
-    with open('{dirname}/assets/{filename}'.format(dirname=os.path.dirname(__file__), filename=filename)) as file:
+    filepath = '{dirname}/assets/{filename}'.format(
+        dirname=os.path.dirname(__file__), filename=filename)
+    
+    with open(filepath, encoding='utf-8') as file:
         return file.read()
 
 

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -24,8 +24,8 @@ def load_asset(filename):
     filepath = '{dirname}/assets/{filename}'.format(
         dirname=os.path.dirname(__file__), filename=filename)
     
-    with open(filepath, encoding='utf-8') as file:
-        return file.read()
+    with open(filepath, mode="rb") as file:
+        return file.read().decode('utf-8')
 
 
 class TestYouTubeTranscriptApi(TestCase):


### PR DESCRIPTION
Changed `def load_asset` helper function in `test/test_api.py` to use an explicit `utf-8` encoding type so Python doesn't default to the default system encoding type. 

Which should fix issue #83 - note this is not meant to fix the ResourceWarning debug output nor the `usage` error when running coverage.