### PR TITLE
Bugfix issue 80 - Add CLI _process_args method for issue 80

### DIFF
--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -9,10 +9,44 @@ from ._api import YouTubeTranscriptApi
 
 class YouTubeTranscriptCli():
     def __init__(self, args):
-        self._args = args
+        self._args = self._process_args(args)
+    
+    def _process_args(self, args, revert=False):
+        """
+        Preprocesses a list of string args.
+
+        The intent is to temporarily alter the leading dash character 
+        on video_ids since argparse recognizes dash characters as
+        "options" rather than arguments.
+
+        :param args: a list of strings of CLI args.
+        :type args: list[str]
+        :param revert: a boolean impacting the translating between 
+        - to # or # to - for the leading character of the video_id. 
+        Default is False.
+        :type revert: boolean
+
+        :return: a new list of processed args where the leading - 
+        character was altered to a #, or leading # character was 
+        altered to a - character. Based on revert being True or False.
+        """
+        from_prefix, to_prefix = ('-','#') if not revert else ('#', '-')
+        new_args = []
+        for arg in args:
+            # ignore leading --, these are in-fact argparse options.
+            if not arg.startswith('--') and arg.startswith(from_prefix):
+                arg = to_prefix + arg[1:] 
+            new_args.append(arg)
+        return new_args
+
 
     def run(self):
         parsed_args = self._parse_args()
+        # Revert the video_ids back to their original - prefixes if any.
+        parsed_args.video_ids = self._process_args(parsed_args.video_ids, revert=True)
+        # We can also revert self._args back.
+        self._args = self._process_args(self._args, revert=True)
+        # Although this may not be necessary since it is only used once.
 
         if parsed_args.exclude_manually_created and parsed_args.exclude_generated:
             return ''


### PR DESCRIPTION
Here is my first pass at trying to fix #80 

Expand the "spoiler" section below for explanations of the issue, the approach I took, and why it's not perfect. 

<details>
<summary>Expand for summary of Problem</summary>
When using the CLI command such as:
`youtube_transcript_api -tiUDjn7-as --languages en --exclude-generated --json`

The `-tiUDjn7` leading `-` video ID case gets interpreted by `argparse.parse_args()` as an option which removes it as an argument passed in making the CLI raise an error `youtube_transcript_api: error: too few arguments`.

The CLI can accept 1 or more video ids and those could all potentially meet this same case. So this means we have to iterate over the args passed into the YouTubeTranscriptCLI. The incoming args for the *command* above looks like this:
`['-tiUDjn7-as', '--languages', 'en', '--exclude-generated', '--json']` and again there can be any number of video IDs. So my thought was to iterate over all of it parsing just the specific leading dash case and leave the rest of the `--` and other args in-tact.

Also, we just cannot accurately determine if we are dealing with an argument versus an option if we run into a video ID that leads with `--`. It just breaks the CLI argparse expectations since youtube accepts these characters. I believe there is an alternative way that we could fix this to avoid this solution entirely but it would break the existing way commands have to be written using the CLI which would be even less ideal.
</details>
<details>
<summary>Expand for summary of solution</summary>
Using this new `def _process_args` method we can use it to temporarily mutate our video_ids.

1. I `_process_args` using the incoming args:
`['-tiUDjn7-as', '--languages', 'en', '--exclude-generated', '--json']`
2. `_process_args` iterates and *only* mutates the video ID strings in this arg list to something like: 
`['#tiUDjn7-as', '--languages', 'en', '--exclude-generated', '--json']`
3. We allow `argparse.parse_args()` to run, now without error. Which returns a Namespace object:
```python
Namespace(list_transcripts=False, video_ids=['#tiUDjn7-as'], languages=['en'], exclude_generated=True, exclude_manually_created=False, json=True, translate='', http_proxy='', https_proxy='', cookies=None)
```
4. Now we need to **revert** the video ID strings back to their original state which we have to do on the stored `.video_ids` attribute that was returned back from `argparse.parse_args()` BEFORE we try to move forward with transcript retrieval. This is done with the same method `self._process_args([...], revert=False)` but passing `revert=False` swaps `#` with `-`.
```python
Namespace(list_transcripts=False, video_ids=['-tiUDjn7-as'], languages=['en'], exclude_generated=True, exclude_manually_created=False, json=True, translate='', http_proxy='', https_proxy='', cookies=None)
```
5. Now we avoided collisions with argparse and the transcript should be able to be retrieved.
</details>

@jdepoix Let me know your thoughts when you have time. We should definitely discuss more around this. I dont think the solution is perfect. It could even be implemented as a utility function instead. But I thought this was a good initial pass and it works for the single leading dash case. 🙂 

**NOTE**: I will get test cases in for coverage issue after we discuss this approach more.