### PR TITLE
Update formatters.py

### DIFF
--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -98,7 +98,7 @@ class WebVTTFormatter(Formatter):
         hours, remainder = divmod(time, 3600)
         mins, secs = divmod(remainder, 60)
         ms = int(round((time - int(time))*1000, 2))
-        return "{:02d}:{:02d}:{:02d}.{:03d}".format(hours, mins, secs, ms)
+        return "{:02.0f}:{:02.0f}:{:02.0f}.{:03d}".format(hours, mins, secs, ms)
 
     def format_transcript(self, transcript, **kwargs):
         """A basic implementation of WEBVTT formatting.

--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -5,9 +5,9 @@ import pprint
 
 class Formatter(object):
     """Formatter should be used as an abstract base class.
-    
+
     Formatter classes should inherit from this class and implement
-    their own .format() method which should return a string. A 
+    their own .format() method which should return a string. A
     transcript is represented by a List of Dictionary items.
     """
 
@@ -95,15 +95,11 @@ class WebVTTFormatter(Formatter):
         '00:00:06.930'
         """
         time = float(time)
-        hours= int(time) // 3600
-        time= time - hours*3600
-        mins, secs = (
-            int(time) // 60,
-            int(time) % 60,
-        )
+        hours, remainder = divmod(time, 3600)
+        mins, secs = divmod(remainder, 60)
         ms = int(round((time - int(time))*1000, 2))
         return "{:02d}:{:02d}:{:02d}.{:03d}".format(hours, mins, secs, ms)
-    
+
     def format_transcript(self, transcript, **kwargs):
         """A basic implementation of WEBVTT formatting.
 
@@ -127,7 +123,7 @@ class WebVTTFormatter(Formatter):
                     self._seconds_to_timestamp(duration)
                 )
             lines.append("{}\n{}".format(time_text, line['text']))
-        
+
         return "WEBVTT\n\n" + "\n\n".join(lines) + "\n"
 
     def format_transcripts(self, transcripts, **kwargs):

--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -95,8 +95,9 @@ class WebVTTFormatter(Formatter):
         '00:00:06.930'
         """
         time = float(time)
-        hours, mins, secs = (
-            int(time) // 3600,
+        hours= int(time) // 3600
+        time= time - hours*3600
+        mins, secs = (
             int(time) // 60,
             int(time) % 60,
         )


### PR DESCRIPTION
corrected hours calculation logic in class WebVTTFormatter  method _seconds_to_timestamp for transcripts with more than an hour length