### PR TITLE
Clarify language rules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ This will return a list of dictionaries looking somewhat like this:
     # ...
 ]
 ```
-### Translate transcript
+### Retrieve different languages
 
 You can add the `languages` param if you want to make sure the transcripts are retrieved in your desired language (it defaults to english).
 
 ```python
-YouTubeTranscriptApi.get_transcript(video_ids, languages=['de', 'en'])
+YouTubeTranscriptApi.get_transcript(video_id, languages=['de', 'en'])
 ```
 
 It's a list of language codes in a descending priority. In this example it will first try to fetch the german transcript (`'de'`) and then fetch the english transcript (`'en'`) if it fails to do so. If you want to find out which languages are available first, [have a look at `list_transcripts()`](#list-available-transcripts).
 
-If you only want one language, you still need to format the languages argument as a list, i.e.,
+If you only want one language, you still need to format the `languages` argument as a list
 
 ```python
-YouTubeTranscriptApi.get_transcript(video_ids, languages=['de'])
+YouTubeTranscriptApi.get_transcript(video_id, languages=['de'])
 ```
 ### Batch fetching of transcripts
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ from youtube_transcript_api import YouTubeTranscriptApi
 YouTubeTranscriptApi.get_transcript(video_id)
 ```
 
+> **Note:** By default, this will try to access the English transcript of the video. If your video has a different language, or you are interested in fetching a different language's transcript, please read the section below.
+
 This will return a list of dictionaries looking somewhat like this:
 
 ```python
@@ -53,15 +55,22 @@ This will return a list of dictionaries looking somewhat like this:
 You can add the `languages` param if you want to make sure the transcripts are retrieved in your desired language (it defaults to english).
 
 ```python
-YouTubeTranscriptApi.get_transcripts(video_ids, languages=['de', 'en'])
+YouTubeTranscriptApi.get_transcript(video_ids, languages=['de', 'en'])
 ```
 
-It's a list of language codes in a descending priority. In this example it will first try to fetch the german transcript (`'de'`) and then fetch the english transcript (`'en'`) if it fails to do so. If you want to find out which languages are available first, [have a look at `list_transcripts()`](#list-available-transcripts)
+It's a list of language codes in a descending priority. In this example it will first try to fetch the german transcript (`'de'`) and then fetch the english transcript (`'en'`) if it fails to do so. If you want to find out which languages are available first, [have a look at `list_transcripts()`](#list-available-transcripts).
+
+If you only want one language, you still need to format the languages argument as a list, i.e.,
+
+```python
+YouTubeTranscriptApi.get_transcript(video_ids, languages=['de'])
+```
+### Batch fetching of transcripts
 
 To get transcripts for a list of video ids you can call:
 
 ```python
-YouTubeTranscriptApi.get_transcripts(video_ids, languages=['de', 'en'])
+YouTubeTranscriptApi.get_transcripts(["video_id1", "video_id2"], languages=['de', 'en'])
 ```
 
 `languages` also is optional here.


### PR DESCRIPTION
With the current documentation, it's unclear what one needs to do if they want the captions for a single video which is not in English, nor what to do if they only want one language, with no fallback (albeit this is slightly clearer than the first case.