### PR TITLE
Fix Cookies.txt chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ youtube_transcript_api <first_video_id> <second_video_id> --https-proxy https://
 
 ## Cookies
 
-Some videos are age restricted, so this module won't be able to access those videos without some sort of authentication. To do this, you will need to have access to the desired video in a browser. Then, you will need to download that pages cookies into a text file. You can use the Chrome extension [cookies.txt](https://chrome.google.com/webstore/detail/cookiestxt/njabckikapfpffapmjgojcnbfjonfjfg?hl=en) or the Firefox extension [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/).
+Some videos are age restricted, so this module won't be able to access those videos without some sort of authentication. To do this, you will need to have access to the desired video in a browser. Then, you will need to download that pages cookies into a text file. You can use the Chrome extension [cookies-local.txt](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc?hl=en) or the Firefox extension [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/).
 
 Once you have that, you can use it with the module to access age-restricted videos' captions like so.
 


### PR DESCRIPTION
The cookies.txt chrome extension is no longer available on the chrome marketplace. I have replaced the link with one that is..