### PR TITLE
Adding better exception for when blocked by bot protection

### DIFF
--- a/youtube_transcript_api/_api.py
+++ b/youtube_transcript_api/_api.py
@@ -16,7 +16,7 @@ from ._errors import (
 
 class YouTubeTranscriptApi(object):
     @classmethod
-    def list_transcripts(cls, video_id, proxies=None, cookies=None):
+    def list_transcripts(cls, video_id, proxies=None, cookies=None, verify=True):
         """
         Retrieves the list of transcripts which are available for a given video. It returns a `TranscriptList` object
         which is iterable and provides methods to filter the list of transcripts for specific languages. While iterating
@@ -61,6 +61,8 @@ class YouTubeTranscriptApi(object):
         :type proxies: {'http': str, 'https': str} - http://docs.python-requests.org/en/master/user/advanced/#proxies
         :param cookies: a string of the path to a text file containing youtube authorization cookies
         :type cookies: str
+        :param verify: SSL Verification default. Will make your application vulnerable to man-in-the-middle (MitM) attacks.
+        :type verify: bool
         :return: the list of available transcripts
         :rtype TranscriptList:
         """
@@ -68,6 +70,7 @@ class YouTubeTranscriptApi(object):
             if cookies:
                 http_client.cookies = cls._load_cookies(cookies, video_id)
             http_client.proxies = proxies if proxies else {}
+            http_client.verify = verify
             return TranscriptListFetcher(http_client).fetch(video_id)
 
     @classmethod

--- a/youtube_transcript_api/_errors.py
+++ b/youtube_transcript_api/_errors.py
@@ -77,6 +77,10 @@ class TranscriptsDisabled(CouldNotRetrieveTranscript):
     CAUSE_MESSAGE = 'Subtitles are disabled for this video'
 
 
+class BotRestricted(CouldNotRetrieveTranscript):
+    CAUSE_MESSAGE = 'Login required because video is restricted by bot detection system'
+
+
 class NoTranscriptAvailable(CouldNotRetrieveTranscript):
     CAUSE_MESSAGE = 'No transcripts are available for this video'
 

--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -16,6 +16,7 @@ from requests import HTTPError
 from ._html_unescaping import unescape
 from ._errors import (
     VideoUnavailable,
+    BotRestricted,
     TooManyRequests,
     YouTubeRequestFailed,
     NoTranscriptFound,
@@ -58,6 +59,8 @@ class TranscriptListFetcher(object):
                 raise TooManyRequests(video_id)
             if '"playabilityStatus":' not in html:
                 raise VideoUnavailable(video_id)
+            if '"playabilityStatus":' in html and '"Sign in to confirm you’re not a bot"' in html:
+                raise BotRestricted(video_id)
 
             raise TranscriptsDisabled(video_id)
 


### PR DESCRIPTION
Adding this because it was hard to debug why I didn't get any transcripts.

A bot restricted HTML text looks like this:

```
"playabilityStatus":{"status":"LOGIN_REQUIRED","reason":"Sign in to confirm you’re not a bot"
```

A healthy HTML text looks like this:

```
"playabilityStatus":{"status":"OK"
```

I was restricted when deployed using a python container on DigitalOcean's App Platform.