### PR TITLE
Handle filtering by single language code in _find_transcript

### DIFF
--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -231,10 +231,15 @@ class TranscriptList(object):
         )
 
     def _find_transcript(self, language_codes, transcript_dicts):
-        for language_code in language_codes:
+        if isinstance(language_codes, str):
             for transcript_dict in transcript_dicts:
                 if language_code in transcript_dict:
                     return transcript_dict[language_code]
+        else:
+            for language_code in language_codes:
+                for transcript_dict in transcript_dicts:
+                    if language_code in transcript_dict:
+                        return transcript_dict[language_code]
 
         raise NoTranscriptFound(self.video_id, language_codes, self)
 


### PR DESCRIPTION
The current implementation of _find_transcript does not account for a single language code being passed as 'code' or ['code']. This causes the outer loop to iterate over the characters in the string, almost guaranteeing raising a NoTranscriptFound, even when the requested language code is available. The fix is done by simply checking if the passed argument is a string, and if so only iterating over the dictionaries.

Notably the function does work if a single code is passed as ['code', ], which is a pretty ugly and hacky work around.