### PR TITLE
Fixed an invalid escape sequence warning.

### DIFF
--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -131,7 +131,7 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.languages, ["en"])
 
     def test_argument_parsing__video_ids_starting_with_dash(self):
-        parsed_args = YouTubeTranscriptCli("\-v1 \-\-v2 \--v3".split())._parse_args()
+        parsed_args = YouTubeTranscriptCli("-v1 --v2 --v3".split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ["-v1", "--v2", "--v3"])
         self.assertEqual(parsed_args.format, "pretty")
         self.assertEqual(parsed_args.languages, ["en"])

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -131,7 +131,7 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.languages, ["en"])
 
     def test_argument_parsing__video_ids_starting_with_dash(self):
-        parsed_args = YouTubeTranscriptCli("-v1 --v2 --v3".split())._parse_args()
+        parsed_args = YouTubeTranscriptCli(r"\-v1 \-\-v2 \--v3".split())._parse_args()
         self.assertEqual(parsed_args.video_ids, ["-v1", "--v2", "--v3"])
         self.assertEqual(parsed_args.format, "pretty")
         self.assertEqual(parsed_args.languages, ["en"])


### PR DESCRIPTION
Fixes the following warning in Python 3.12:

./.venv/lib/python3.12/site-packages/youtube_transcript_api/test/test_cli.py:134: SyntaxWarning: invalid escape sequence '-'
parsed_args = YouTubeTranscriptCli("-v1 --v2 --v3".split())._parse_args()
