### PR TITLE
Feature/rotate proxy ip on block

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ therefore integrated it into this module, to make setting it up as easy as possi
 
 Once you have created a [Webshare account](https://www.webshare.io/?referral_code=w0xno53eb50g) and purchased a 
 "Residential" proxy package that suits your workload (make sure NOT to purchase "Proxy Server" or 
-"Static Residential"!), open the [Webshare Proxy Settings](https://dashboard.webshare.io/proxy/settings) to retrieve 
+"Static Residential"!), open the 
+[Webshare Proxy Settings](https://dashboard.webshare.io/proxy/settings?referral_code=w0xno53eb50g) to retrieve 
 your "Proxy Username" and "Proxy Password". Using this information you can initialize the `YouTubeTranscriptApi` as 
 follows:
 
@@ -306,8 +307,8 @@ ytt_api.fetch(video_id)
 Using the `WebshareProxyConfig` will default to using rotating residential proxies and requires no further 
 configuration.
 
-Note that referral links are used here and any purchases made through these links will support this Open Source 
-project, which is very much appreciated! 💖😊🙏💖
+Note that [referral links are used here](https://www.webshare.io/?referral_code=w0xno53eb50g) and any purchases 
+made through these links will support this Open Source project, which is very much appreciated! 💖😊🙏💖
 
 However, you are of course free to integrate your own proxy solution using the `GenericProxyConfig` class, if you 
 prefer using another provider or want to implement your own solution, as covered by the following section.
@@ -511,7 +512,7 @@ using residential proxies as explained in
 create a [Webshare account](https://www.webshare.io/?referral_code=w0xno53eb50g) and purchase a "Residential" proxy 
 package that suits your workload (make sure NOT to purchase "Proxy Server" or "Static Residential"!). Then you can use 
 the "Proxy Username" and "Proxy Password" which you can find in your 
-[Webshare Proxy Settings](https://dashboard.webshare.io/proxy/settings), to run the following command:
+[Webshare Proxy Settings](https://dashboard.webshare.io/proxy/settings?referral_code=w0xno53eb50g), to run the following command:
 
 ```
 youtube_transcript_api <first_video_id> <second_video_id> --webshare-proxy-username "username" --webshare-proxy-password "password"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "youtube-transcript-api"
-version = "1.0.1"
+version = "1.0.2"
 description = "This is an python API which allows you to get the transcripts/subtitles for a given YouTube video. It also works for automatically generated subtitles, supports translating subtitles and it does not require a headless browser, like other selenium based solutions do!"
 readme = "README.md"
 license = "MIT"

--- a/youtube_transcript_api/_api.py
+++ b/youtube_transcript_api/_api.py
@@ -48,9 +48,9 @@ class YouTubeTranscriptApi:
             http_client.cookies = _load_cookie_jar(cookie_path)
         if proxy_config is not None:
             http_client.proxies = proxy_config.to_requests_dict()
-            if proxy_config.prevent_keeping_connections_alive():
+            if proxy_config.prevent_keeping_connections_alive:
                 http_client.headers.update({"Connection": "close"})
-        self._fetcher = TranscriptListFetcher(http_client)
+        self._fetcher = TranscriptListFetcher(http_client, proxy_config=proxy_config)
 
     def fetch(
         self,

--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -364,7 +364,7 @@ class TranscriptListFetcher:
             )
             if try_number + 1 < retries:
                 return self._fetch_captions_json(video_id, try_number=try_number + 1)
-            raise exception
+            raise exception.with_proxy_config(self._proxy_config)
 
     def _extract_captions_json(self, html: str, video_id: str) -> Dict:
         splitted_html = html.split("var ytInitialPlayerResponse = ")

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -247,8 +247,10 @@ class TestYouTubeTranscriptApi(TestCase):
             httpretty.GET, "https://www.youtube.com/watch", status=500
         )
 
-        with self.assertRaises(YouTubeRequestFailed):
+        with self.assertRaises(YouTubeRequestFailed) as cm:
             YouTubeTranscriptApi().fetch("abc")
+
+        self.assertIn("Request to YouTube failed: ", str(cm.exception))
 
     def test_fetch__exception_if_age_restricted(self):
         httpretty.register_uri(
@@ -277,8 +279,10 @@ class TestYouTubeTranscriptApi(TestCase):
             body=load_asset("youtube_request_blocked.html.static"),
         )
 
-        with self.assertRaises(RequestBlocked):
+        with self.assertRaises(RequestBlocked) as cm:
             YouTubeTranscriptApi().fetch("Njp5uhTorCo")
+
+        self.assertIn("YouTube is blocking requests from your IP", str(cm.exception))
 
     def test_fetch__exception_unplayable(self):
         httpretty.register_uri(
@@ -287,11 +291,12 @@ class TestYouTubeTranscriptApi(TestCase):
             body=load_asset("youtube_unplayable.html.static"),
         )
 
-        with self.assertRaises(VideoUnplayable) as error:
+        with self.assertRaises(VideoUnplayable) as cm:
             YouTubeTranscriptApi().fetch("Njp5uhTorCo")
-        error = error.exception
-        self.assertEqual(error.reason, "Custom Reason")
-        self.assertEqual(error.sub_reasons, ["Sub Reason 1", "Sub Reason 2"])
+        exception = cm.exception
+        self.assertEqual(exception.reason, "Custom Reason")
+        self.assertEqual(exception.sub_reasons, ["Sub Reason 1", "Sub Reason 2"])
+        self.assertIn("Custom Reason", str(exception))
 
     def test_fetch__exception_if_transcripts_disabled(self):
         httpretty.register_uri(
@@ -312,8 +317,10 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("Fjg5lYqvzUs")
 
     def test_fetch__exception_if_language_unavailable(self):
-        with self.assertRaises(NoTranscriptFound):
+        with self.assertRaises(NoTranscriptFound) as cm:
             YouTubeTranscriptApi().fetch("GJLlxj_dtq8", languages=["cz"])
+
+        self.assertIn("No transcripts were found for", str(cm.exception))
 
     @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
     def test_fetch__with_proxy(self, to_requests_dict):
@@ -359,7 +366,7 @@ class TestYouTubeTranscriptApi(TestCase):
         self.assertEqual(len(httpretty.latest_requests()), 3 + 2)
 
     @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
-    def test_fetch__with_proxy_reraise_when_blocked(self, to_requests_dict):
+    def test_fetch__with_webshare_proxy_reraise_when_blocked(self, to_requests_dict):
         retries = 5
         for _ in range(retries):
             httpretty.register_uri(
@@ -373,10 +380,31 @@ class TestYouTubeTranscriptApi(TestCase):
             retries_when_blocked=retries,
         )
 
-        with self.assertRaises(RequestBlocked):
+        with self.assertRaises(RequestBlocked) as cm:
             YouTubeTranscriptApi(proxy_config=proxy_config).fetch("Njp5uhTorCo")
 
         self.assertEqual(len(httpretty.latest_requests()), retries)
+        self.assertEqual(cm.exception._proxy_config, proxy_config)
+        self.assertIn("Webshare", str(cm.exception))
+
+    @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
+    def test_fetch__with_generic_proxy_reraise_when_blocked(self, to_requests_dict):
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://www.youtube.com/watch",
+            body=load_asset("youtube_request_blocked.html.static"),
+        )
+        proxy_config = GenericProxyConfig(
+            http_url="http://localhost:8080",
+            https_url="http://localhost:8080",
+        )
+
+        with self.assertRaises(RequestBlocked) as cm:
+            YouTubeTranscriptApi(proxy_config=proxy_config).fetch("Njp5uhTorCo")
+
+        self.assertEqual(len(httpretty.latest_requests()), 1)
+        self.assertEqual(cm.exception._proxy_config, proxy_config)
+        self.assertIn("YouTube is blocking your requests", str(cm.exception))
 
     def test_fetch__with_cookies(self):
         cookie_path = get_asset_path("example_cookies.txt")


### PR DESCRIPTION
- Adds retry mechanism, which will retry requests when Webshare proxies are used and `RequestBlocked` is raised, to trigger an IP rotation in case a user encounters a blocked residential IP
- Adds new error message when `RequestBlocked` is raised while already using proxies, to assist user in figuring out what the issue is