### PR TITLE
 Add YouTubeResponseIsEmpty exception to handle empty YouTube responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ upload_new_version.sh
 .coverage
 coverage.xml
 .DS_STORE
+.vscode/

--- a/youtube_transcript_api/_errors.py
+++ b/youtube_transcript_api/_errors.py
@@ -76,6 +76,14 @@ class YouTubeDataUnparsable(CouldNotRetrieveTranscript):
     )
 
 
+class YouTubeResponseIsEmpty(CouldNotRetrieveTranscript):
+    CAUSE_MESSAGE = (
+        "Request to YouTube was successful, but the response's content is empty, "
+        "so the transcript parsing cannot be performed. "
+        "Retry later."
+    )
+
+
 class YouTubeRequestFailed(CouldNotRetrieveTranscript):
     CAUSE_MESSAGE = "Request to YouTube failed: {reason}"
 

--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -15,6 +15,7 @@ from requests import HTTPError, Session, Response
 from .proxies import ProxyConfig
 from ._errors import (
     VideoUnavailable,
+    YouTubeResponseIsEmpty,
     YouTubeRequestFailed,
     NoTranscriptFound,
     TranscriptsDisabled,
@@ -131,8 +132,12 @@ class Transcript:
         :param preserve_formatting: whether to keep select HTML text formatting
         """
         response = self._http_client.get(self._url)
+        response_text = _raise_http_errors(response, self.video_id).text
+        if not response_text:
+            raise YouTubeResponseIsEmpty(self.video_id)
+
         snippets = _TranscriptParser(preserve_formatting=preserve_formatting).parse(
-            _raise_http_errors(response, self.video_id).text,
+            response_text
         )
         return FetchedTranscript(
             snippets=snippets,


### PR DESCRIPTION
**Title**  
➔ Add `YouTubeResponseIsEmpty` exception to handle empty YouTube responses

**Description**  
This PR introduces a new `YouTubeResponseIsEmpty` exception, derived from `CouldNotRetrieveTranscript`.  
It is raised when a request to YouTube succeeds but the response content is empty, making transcript parsing impossible.

Main changes:  
- Added the `YouTubeResponseIsEmpty` class in `_errors.py`.
- Updated `_transcripts.py` to check if the response content is empty before attempting to parse it.
- Improved error handling for cases where YouTube returns an empty response without an HTTP error.

This enhancement provides clearer diagnostics for this specific failure scenario and suggests retrying later, as indicated in the exception message.
