### PR TITLE
Add support for self‑signed proxy connections

### DIFF
--- a/youtube_transcript_api/_api.py
+++ b/youtube_transcript_api/_api.py
@@ -37,6 +37,10 @@ class YouTubeTranscriptApi:
         #     http_client.cookies = _load_cookie_jar(cookie_path)
         if proxy_config is not None:
             http_client.proxies = proxy_config.to_requests_dict()
+
+            if proxy_config.allow_self_signed:
+                http_client.verify = False
+
             if proxy_config.prevent_keeping_connections_alive:
                 http_client.headers.update({"Connection": "close"})
             if proxy_config.retries_when_blocked > 0:

--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -24,7 +24,8 @@ class YouTubeTranscriptCli:
                 http_url=parsed_args.http_proxy,
                 https_url=parsed_args.https_proxy,
             )
-
+            if parsed_args.insecure_proxy:
+                proxy_config.allow_self_signed = True
         if (
             parsed_args.webshare_proxy_username is not None
             or parsed_args.webshare_proxy_password is not None
@@ -187,6 +188,11 @@ class YouTubeTranscriptCli:
             default="",
             metavar="URL",
             help="Use the specified HTTPS proxy.",
+        )
+        parser.add_argument(
+            "--insecure-proxy",
+            action="store_true",
+            help="Allow insecure proxy connections with self-signed certificates.",
         )
         # Cookie auth has been temporarily disabled, as it is not working properly with
         # YouTube's most recent changes.

--- a/youtube_transcript_api/proxies.py
+++ b/youtube_transcript_api/proxies.py
@@ -22,6 +22,13 @@ class ProxyConfig(ABC):
     The base class for all proxy configs. Anything can be a proxy config, as longs as
     it can be turned into a `RequestsProxyConfigDict` by calling `to_requests_dict`.
     """
+    @property
+    def allow_self_signed(self) -> bool:
+        return getattr(self, "_allow_self_signed", False)
+
+    @allow_self_signed.setter
+    def allow_self_signed(self, value: bool):
+        self._allow_self_signed = bool(value)
 
     @abstractmethod
     def to_requests_dict(self) -> RequestsProxyConfigDict:


### PR DESCRIPTION
- Introduce `allow_self_signed` flag in `ProxyConfig`.
- Propagate flag to HTTP client (`verify=False`).
- Add `--insecure-proxy` CLI option to enable the flag.
- Adjust proxy handling logic accordingly.