### PR TITLE
fix: prevent duplicate -rotate suffix in proxy username

### DIFF
--- a/youtube_transcript_api/proxies.py
+++ b/youtube_transcript_api/proxies.py
@@ -160,8 +160,12 @@ class WebshareProxyConfig(GenericProxyConfig):
         location_codes = "".join(
             f"-{location_code.upper()}" for location_code in self._filter_ip_locations
         )
+        username = self.proxy_username
+        suffix = "-rotate"
+        if username.endswith(suffix):
+            username = username[: -len(suffix)]
         return (
-            f"http://{self.proxy_username}{location_codes}-rotate:{self.proxy_password}"
+            f"http://{username}{location_codes}{suffix}:{self.proxy_password}"
             f"@{self.domain_name}:{self.proxy_port}/"
         )
 

--- a/youtube_transcript_api/test/test_proxies.py
+++ b/youtube_transcript_api/test/test_proxies.py
@@ -91,3 +91,15 @@ class TestWebshareProxyConfig:
             "http": "http://user-DE-US-rotate:password@p.webshare.io:80/",
             "https": "http://user-DE-US-rotate:password@p.webshare.io:80/",
         }
+
+    def test_to_requests_dict__with_rotate_suffix_in_username(self):
+        proxy_config = WebshareProxyConfig(
+            proxy_username="user-rotate", proxy_password="password"
+        )
+
+        request_dict = proxy_config.to_requests_dict()
+
+        assert request_dict == {
+            "http": "http://user-rotate:password@p.webshare.io:80/",
+            "https": "http://user-rotate:password@p.webshare.io:80/",
+        }


### PR DESCRIPTION
Currently, `WebshareProxyConfig` automatically appends -rotate to the proxy username. This has caused unexpected errors for some users (see #560 , #562 ).

I also encountered a 407 error recently (it was working fine until recently—not sure why, perhaps something changed on Webshare's side), which led me to discover this issue.
In my case, I store the proxy username as a secret and use it across multiple services, so having to handle this library differently is inconvenient.

To prevent such unexpected errors, how about explicitly stripping the -rotate suffix from the username if it already exists?
Alternatively, if this approach isn't preferred, we could raise an explicit error during config initialization when a duplicate suffix is detected.