### PR TITLE
Debian Packaging: Add manpage for youtube_transcript_api CLI

### DIFF
--- a/man/youtube_transcript_api.1
+++ b/man/youtube_transcript_api.1
@@ -1,0 +1,33 @@
+.TH YOUTUBE_TRANSCRIPT_API 1 "February 2026" "1.2.4" "User Commands"
+.SH NAME
+youtube_transcript_api \- retrieve transcripts and subtitles from YouTube videos
+.SH SYNOPSIS
+.B youtube_transcript_api
+[\fIvideo_id\fR ...] [\fIoptions\fR]
+.SH DESCRIPTION
+\fByoutube_transcript_api\fR is a command line interface to retrieve transcripts
+and subtitles for a given YouTube video[cite: 2]. It supports automatically generated
+subtitles, translations, and does not require a headless browser[cite: 2].
+.SH OPTIONS
+.TP
+.BI \fIvideo_id\fR
+The ID(s) of the YouTube video(s) to retrieve transcripts for.
+.TP
+.B \-\-list
+List available transcripts for the given video ID.
+.TP
+.BI \-\-languages " lang1 lang2"
+Specify a list of language codes in order of priority.
+.TP
+.BI \-\-cookies " cookie_path"
+Path to a cookies file for authentication (required for some videos).
+.TP
+.B \-\-format
+Specify output format (json, text).
+.SH EXAMPLES
+.B youtube_transcript_api GJLlxj_dtq8
+.PP
+.B youtube_transcript_api GJLlxj_dtq8 --languages de en
+.SH AUTHOR
+Maintained by the Debian Python Team <team+python@tracker.debian.org>[cite: 2].
+Upstream author: Jonas Depoix <jonas.depoix@web.de>[cite: 2, 4].


### PR DESCRIPTION
Hi,

I am currently preparing the official Debian package for youtube-transcript-api.

As part of the Debian Policy, every executable in /usr/bin must be accompanied by a manual page. I have authored this basic manpage to ensure the package meets these standards.

Instead of keeping this as a downstream-only patch in Debian, I would like to contribute it to your repository so all Linux distributions and CLI users can benefit from it.

Please note that the package needs a code review before it goes in the NEW Queue. The NEW queue is a manual review process by the Debian FTP Masters, where every new source package is checked for license compliance and technical guidelines before it can be officially accepted into the archive. 

Currently, there is a significant backlog (581 packages in NEW out of 626 total pending), so it might take some time for the first code review to be completed and for the package to enter the archives. 

I will keep you updated on the progress.

If you have questions, do not hesitate to ask.

Regards,
Arian Ott