### PR TITLE
Refactor/replace httpretty with responses

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
@@ -18,7 +18,7 @@ version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -241,23 +241,12 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "httpretty"
-version = "1.0.5"
-description = "HTTP client mock for Python"
-optional = false
-python-versions = ">=3"
-groups = ["test"]
-files = [
-    {file = "httpretty-1.0.5.tar.gz", hash = "sha256:e53c927c4d3d781a0761727f1edfad64abef94e828718e12b672a678a8b3e0b5"},
-]
-
-[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -330,12 +319,95 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -350,6 +422,26 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37"},
+    {file = "responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli ; python_version < \"3.11\"", "tomli-w", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "ruff"
@@ -428,7 +520,7 @@ version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
     {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
@@ -443,4 +535,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.15"
-content-hash = "fcec31b0d567d2940e2a5e720ef9b53deba9b085701ea8e4fbdfecc2c400b95a"
+content-hash = "34bdc0ef7b905a807195902bdfdd5db84e0bc5ccd0f6cb1883c35004a6e06dd6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ optional = true
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.3"
 coverage = "^7.6.1"
-httpretty = "<1.1"
+responses = "^0.26.0"
 
 [tool.poetry.group.dev]
 optional = true

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -3,10 +3,10 @@ import os
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
+from urllib.parse import urlparse, parse_qs
 
 import requests
-
-import httpretty
+import responses
 
 from youtube_transcript_api import (
     YouTubeTranscriptApi,
@@ -46,6 +46,10 @@ def load_asset(filename: str):
 
 class TestYouTubeTranscriptApi(TestCase):
     def setUp(self):
+        responses.start()
+        self.addCleanup(responses.stop)
+        self.addCleanup(responses.reset)
+
         self.ref_transcript = FetchedTranscript(
             snippets=[
                 FetchedTranscriptSnippet(
@@ -70,26 +74,20 @@ class TestYouTubeTranscriptApi(TestCase):
             video_id="GJLlxj_dtq8",
         )
         self.ref_transcript_raw = self.ref_transcript.to_raw_data()
-        httpretty.enable()
-        httpretty.register_uri(
-            httpretty.POST,
+
+        responses.post(
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube.innertube.json.static"),
+            content_type="application/json",
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.get(
             "https://www.youtube.com/watch",
             body=load_asset("youtube.html.static"),
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.get(
             "https://www.youtube.com/api/timedtext",
             body=load_asset("transcript.xml.static"),
         )
-
-    def tearDown(self):
-        httpretty.reset()
-        httpretty.disable()
 
     def test_fetch(self):
         transcript = YouTubeTranscriptApi().fetch("GJLlxj_dtq8")
@@ -112,8 +110,8 @@ class TestYouTubeTranscriptApi(TestCase):
         )
 
     def test_fetch__with_altered_user_agent(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_altered_user_agent.innertube.json.static"),
         )
@@ -151,8 +149,8 @@ class TestYouTubeTranscriptApi(TestCase):
         self.assertTrue(transcript.is_generated)
 
     def test_list__url_as_video_id(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_video_unavailable.innertube.json.static"),
         )
@@ -185,54 +183,67 @@ class TestYouTubeTranscriptApi(TestCase):
 
     def test_fetch__correct_language_is_used(self):
         YouTubeTranscriptApi().fetch("GJLlxj_dtq8", ["de", "en"])
-        query_string = httpretty.last_request().querystring
+        parsed_url = urlparse(responses.calls[-1].request.url)
+        query_string = parse_qs(parsed_url.query)
 
         self.assertIn("lang", query_string)
         self.assertEqual(len(query_string["lang"]), 1)
         self.assertEqual(query_string["lang"][0], "de")
 
     def test_fetch__fallback_language_is_used(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_ww1_nl_en.innertube.json.static"),
         )
 
         YouTubeTranscriptApi().fetch("F1xioXWb8CY", ["de", "en"])
-        query_string = httpretty.last_request().querystring
+        parsed_url = urlparse(responses.calls[-1].request.url)
+        query_string = parse_qs(parsed_url.query)
 
         self.assertIn("lang", query_string)
         self.assertEqual(len(query_string["lang"]), 1)
         self.assertEqual(query_string["lang"][0], "en")
 
     def test_fetch__create_consent_cookie_if_needed(self):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             "https://www.youtube.com/watch",
             body=load_asset("youtube_consent_page.html.static"),
         )
+        responses.add(
+            responses.GET,
+            "https://www.youtube.com/watch",
+            body=load_asset("youtube.html.static"),
+        )
 
         YouTubeTranscriptApi().fetch("F1xioXWb8CY")
-        self.assertEqual(len(httpretty.latest_requests()), 4)
-        for request in httpretty.latest_requests()[1:]:
+        self.assertEqual(len(responses.calls), 4)
+
+        for call in responses.calls[1:]:
             self.assertEqual(
-                request.headers["cookie"], "CONSENT=YES+cb.20210328-17-p0.de+FX+119"
+                call.request.headers["cookie"],
+                "CONSENT=YES+cb.20210328-17-p0.de+FX+119",
             )
 
     def test_fetch__exception_if_create_consent_cookie_failed(self):
-        for _ in range(2):
-            httpretty.register_uri(
-                httpretty.GET,
-                "https://www.youtube.com/watch",
-                body=load_asset("youtube_consent_page.html.static"),
-            )
+        responses.replace(
+            responses.GET,
+            "https://www.youtube.com/watch",
+            body=load_asset("youtube_consent_page.html.static"),
+        )
+        responses.add(
+            responses.GET,
+            "https://www.youtube.com/watch",
+            body=load_asset("youtube_consent_page.html.static"),
+        )
 
         with self.assertRaises(FailedToCreateConsentCookie):
             YouTubeTranscriptApi().fetch("F1xioXWb8CY")
 
     def test_fetch__exception_if_consent_cookie_age_invalid(self):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             "https://www.youtube.com/watch",
             body=load_asset("youtube_consent_page_invalid.html.static"),
         )
@@ -241,8 +252,8 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("F1xioXWb8CY")
 
     def test_fetch__exception_if_video_unavailable(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_video_unavailable.innertube.json.static"),
         )
@@ -251,8 +262,8 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("abc")
 
     def test_fetch__exception_if_youtube_request_fails(self):
-        httpretty.register_uri(
-            httpretty.POST, "https://www.youtube.com/youtubei/v1/player", status=500
+        responses.replace(
+            responses.POST, "https://www.youtube.com/youtubei/v1/player", status=500
         )
 
         with self.assertRaises(YouTubeRequestFailed) as cm:
@@ -263,8 +274,8 @@ class TestYouTubeTranscriptApi(TestCase):
     def test_fetch__exception_if_youtube_request_limit_reached(
         self,
     ):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             "https://www.youtube.com/watch",
             body=load_asset("youtube_too_many_requests.html.static"),
         )
@@ -275,8 +286,8 @@ class TestYouTubeTranscriptApi(TestCase):
     def test_fetch__exception_if_timedtext_request_limit_reached(
         self,
     ):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             "https://www.youtube.com/api/timedtext",
             status=429,
         )
@@ -285,8 +296,8 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("abc")
 
     def test_fetch__exception_if_age_restricted(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_age_restricted.innertube.json.static"),
         )
@@ -295,8 +306,8 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("Njp5uhTorCo")
 
     def test_fetch__exception_if_ip_blocked(self):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             "https://www.youtube.com/watch",
             body=load_asset("youtube_too_many_requests.html.static"),
         )
@@ -305,8 +316,8 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("abc")
 
     def test_fetch__exception_if_po_token_required(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_po_token_required.innertube.json.static"),
         )
@@ -315,10 +326,11 @@ class TestYouTubeTranscriptApi(TestCase):
             YouTubeTranscriptApi().fetch("GJLlxj_dtq8")
 
     def test_fetch__exception_request_blocked(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_request_blocked.innertube.json.static"),
+            content_type="application/json",
         )
 
         with self.assertRaises(RequestBlocked) as cm:
@@ -327,8 +339,8 @@ class TestYouTubeTranscriptApi(TestCase):
         self.assertIn("YouTube is blocking requests from your IP", str(cm.exception))
 
     def test_fetch__exception_unplayable(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_unplayable.innertube.json.static"),
         )
@@ -341,8 +353,8 @@ class TestYouTubeTranscriptApi(TestCase):
         self.assertIn("Custom Reason", str(exception))
 
     def test_fetch__exception_if_transcripts_disabled(self):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_transcripts_disabled.innertube.json.static"),
         )
@@ -350,8 +362,8 @@ class TestYouTubeTranscriptApi(TestCase):
         with self.assertRaises(TranscriptsDisabled):
             YouTubeTranscriptApi().fetch("dsMFmonKDD4")
 
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_transcripts_disabled2.innertube.json.static"),
         )
@@ -387,17 +399,31 @@ class TestYouTubeTranscriptApi(TestCase):
 
         YouTubeTranscriptApi(proxy_config=proxy_config).fetch("GJLlxj_dtq8")
 
-        request = httpretty.last_request()
+        request = responses.calls[-1].request
         self.assertEqual(request.headers.get("Connection"), "close")
 
     @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
     def test_fetch__with_proxy_retry_when_blocked(self, to_requests_dict):
-        for _ in range(3):
-            httpretty.register_uri(
-                httpretty.POST,
+        responses.replace(
+            responses.POST,
+            "https://www.youtube.com/youtubei/v1/player",
+            body=load_asset("youtube_request_blocked.innertube.json.static"),
+            content_type="application/json",
+        )
+        for _ in range(2):
+            responses.add(
+                responses.POST,
                 "https://www.youtube.com/youtubei/v1/player",
                 body=load_asset("youtube_request_blocked.innertube.json.static"),
+                content_type="application/json",
             )
+        responses.add(
+            responses.POST,
+            "https://www.youtube.com/youtubei/v1/player",
+            body=load_asset("youtube.innertube.json.static"),
+            content_type="application/json",
+        )
+
         proxy_config = WebshareProxyConfig(
             proxy_username="username",
             proxy_password="password",
@@ -405,17 +431,25 @@ class TestYouTubeTranscriptApi(TestCase):
 
         YouTubeTranscriptApi(proxy_config=proxy_config).fetch("Njp5uhTorCo")
 
-        self.assertEqual(len(httpretty.latest_requests()), 2 * 3 + 3)
+        self.assertEqual(len(responses.calls), 2 * 3 + 3)
 
     @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
     def test_fetch__with_webshare_proxy_reraise_when_blocked(self, to_requests_dict):
         retries = 5
-        for _ in range(retries):
-            httpretty.register_uri(
-                httpretty.POST,
+        responses.replace(
+            responses.POST,
+            "https://www.youtube.com/youtubei/v1/player",
+            body=load_asset("youtube_request_blocked.innertube.json.static"),
+            content_type="application/json",
+        )
+        for _ in range(retries - 1):
+            responses.add(
+                responses.POST,
                 "https://www.youtube.com/youtubei/v1/player",
                 body=load_asset("youtube_request_blocked.innertube.json.static"),
+                content_type="application/json",
             )
+
         proxy_config = WebshareProxyConfig(
             proxy_username="username",
             proxy_password="password",
@@ -425,17 +459,19 @@ class TestYouTubeTranscriptApi(TestCase):
         with self.assertRaises(RequestBlocked) as cm:
             YouTubeTranscriptApi(proxy_config=proxy_config).fetch("Njp5uhTorCo")
 
-        self.assertEqual(len(httpretty.latest_requests()), retries * 2)
+        self.assertEqual(len(responses.calls), retries * 2)
         self.assertEqual(cm.exception._proxy_config, proxy_config)
         self.assertIn("Webshare", str(cm.exception))
 
     @patch("youtube_transcript_api.proxies.GenericProxyConfig.to_requests_dict")
     def test_fetch__with_generic_proxy_reraise_when_blocked(self, to_requests_dict):
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.replace(
+            responses.POST,
             "https://www.youtube.com/youtubei/v1/player",
             body=load_asset("youtube_request_blocked.innertube.json.static"),
+            content_type="application/json",
         )
+
         proxy_config = GenericProxyConfig(
             http_url="http://localhost:8080",
             https_url="http://localhost:8080",
@@ -444,7 +480,7 @@ class TestYouTubeTranscriptApi(TestCase):
         with self.assertRaises(RequestBlocked) as cm:
             YouTubeTranscriptApi(proxy_config=proxy_config).fetch("Njp5uhTorCo")
 
-        self.assertEqual(len(httpretty.latest_requests()), 2)
+        self.assertEqual(len(responses.calls), 2)
         self.assertEqual(cm.exception._proxy_config, proxy_config)
         self.assertIn("YouTube is blocking your requests", str(cm.exception))
 


### PR DESCRIPTION
This PR migrates the test suite's HTTP mocking library from httpretty (which is no langer actively maintained) to responses to provide better stability and integration with the requests library. The existing `unittest.TestCase` architecture was preserved to keep the refactor focused and the diff clean.

## Key Changes
- Mock Lifecycle: Replaced `httpretty.activate` with `responses.start()` and `self.addCleanup(responses.stop)` inside `setUp()` to ensure base mocks persist correctly across the test lifecycle.

- State Overrides: Used `responses.replace()` and chained `responses.add()` calls to handle test-specific mock overrides and sequential retry logic (e.g., for proxy and consent cookie tests).

- Content-Type Fixes: Explicitly added `content_type="application/json"` to innertube API mocks. responses defaults to text/plain, which was preventing the error handler from parsing JSON and causing false-positive `VideoUnplayable` exceptions.