### PR TITLE
Add alternative entrypoint for better tool runner use

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,14 @@ Execute the CLI script using the video ids as parameters and the results will be
 youtube_transcript_api <first_video_id> <second_video_id> ...  
 ```  
 
+You can also run the CLI without installing it using [uvx](https://docs.astral.sh/uv/guides/tools/) or [pipx](https://pipx.pypa.io/):
+
+```
+uvx youtube-transcript-api <first_video_id> <second_video_id> ...
+```
+
+
+
 The CLI also gives you the option to provide a list of preferred languages:  
 
 ```  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
 
 [tool.poetry.scripts]
 youtube_transcript_api = "youtube_transcript_api.__main__:main"
+youtube-transcript-api = "youtube_transcript_api.__main__:main"
 
 [tool.poe.tasks]
 test = "pytest youtube_transcript_api"


### PR DESCRIPTION
Hello!

This adds an alternative entrypoint that matches the package name to allow a simplier way to run via tool runners like `uvx`.

```plain
$ uvx youtube-transcript-api ... --format text
Installed 7 packages in 9ms
An executable named `youtube-transcript-api` is not provided by package `youtube-transcript-api`.
The following executables are available:
- youtube_transcript_api

Use `uvx --from youtube-transcript-api youtube_transcript_api` instead.
```