### PR TITLE
fix(cli): accept YouTube video IDs starting with a dash

### DIFF
--- a/youtube_transcript_api/_cli.py
+++ b/youtube_transcript_api/_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 from importlib.metadata import PackageNotFoundError, version
 from typing import List
 
@@ -8,9 +9,28 @@ from .formatters import FormatterLoader
 from ._api import YouTubeTranscriptApi, FetchedTranscript, TranscriptList
 
 
+# YouTube video IDs are 11 characters long and may contain letters, digits,
+# underscores, and hyphens. When an ID starts with a hyphen (e.g. "-X9P8VE94Po")
+# argparse mistakes it for an unknown option. We detect that pattern and
+# pre-escape it with a backslash, which is then stripped by
+# ``_sanitize_video_ids`` after parsing.
+#
+# The second character must not be ``-`` so that long options such as
+# ``--languages`` (which happens to be 11 characters long) are not
+# misclassified as video IDs. Video IDs starting with ``--`` are extremely
+# rare and can still be passed using the existing backslash escape.
+_VIDEO_ID_STARTING_WITH_DASH_RE = re.compile(r"^-[A-Za-z0-9_][A-Za-z0-9_-]{9}$")
+
+
 class YouTubeTranscriptCli:
     def __init__(self, args: List[str]):
-        self._args = args
+        self._args = [self._escape_video_id_starting_with_dash(arg) for arg in args]
+
+    @staticmethod
+    def _escape_video_id_starting_with_dash(arg: str) -> str:
+        if _VIDEO_ID_STARTING_WITH_DASH_RE.match(arg):
+            return "\\" + arg
+        return arg
 
     def run(self) -> str:
         parsed_args = self._parse_args()

--- a/youtube_transcript_api/test/test_cli.py
+++ b/youtube_transcript_api/test/test_cli.py
@@ -139,6 +139,29 @@ class TestYouTubeTranscriptCli(TestCase):
         self.assertEqual(parsed_args.format, "pretty")
         self.assertEqual(parsed_args.languages, ["en"])
 
+    def test_argument_parsing__youtube_id_starting_with_dash_is_auto_escaped(self):
+        # 11-char YouTube IDs starting with "-" must not be interpreted as
+        # options by argparse, even when other flags follow.
+        parsed_args = YouTubeTranscriptCli(
+            "-X9P8VE94Po --format text".split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ["-X9P8VE94Po"])
+        self.assertEqual(parsed_args.format, "text")
+
+        parsed_args = YouTubeTranscriptCli(
+            "-X9P8VE94Po -abcdefghij --languages de en".split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ["-X9P8VE94Po", "-abcdefghij"])
+        self.assertEqual(parsed_args.languages, ["de", "en"])
+
+        # Existing options must still be recognized; only 11-char ID-like
+        # tokens are auto-escaped.
+        parsed_args = YouTubeTranscriptCli(
+            "v1 --format json".split()
+        )._parse_args()
+        self.assertEqual(parsed_args.video_ids, ["v1"])
+        self.assertEqual(parsed_args.format, "json")
+
     def test_argument_parsing__fail_without_video_ids(self):
         with self.assertRaises(SystemExit):
             YouTubeTranscriptCli("--format json".split())._parse_args()


### PR DESCRIPTION
Fixes #599.

## Problem

`argparse` treats any positional token starting with `-` as an unknown option, so a YouTube video ID with a leading dash makes the CLI error out:

```bash
$ youtube_transcript_api -X9P8VE94Po --format text
youtube_transcript_api: error: unrecognized arguments: -X9P8VE94Po
```

The existing `\-` escape works but is undocumented, and the `--` separator does not help because it forces every following token (including flags) to be treated as a positional video ID.

## Change

`YouTubeTranscriptCli.__init__` now pre-escapes any incoming token matching the YouTube video ID pattern with a single leading dash:

```
^-[A-Za-z0-9_][A-Za-z0-9_-]{9}$
```

by prepending a backslash before argparse runs. The existing `_sanitize_video_ids` step strips that backslash after parsing, so the resulting `video_ids` list contains the original IDs.

The second character is required to be non-`-` so that long options such as `--languages` (which is also 11 characters long) are not misclassified as video IDs. Video IDs starting with `--` are extremely rare and can still be passed using the existing manual `\` escape.

## Tests

Added `test_argument_parsing__youtube_id_starting_with_dash_is_auto_escaped` covering:

- `-X9P8VE94Po --format text` parses as `video_ids=['-X9P8VE94Po'], format='text'`
- Multiple dash-prefixed IDs followed by `--languages de en` parse correctly
- Normal IDs and options are unaffected

Existing `test_argument_parsing__video_ids_starting_with_dash` (manual `\` escape) still passes.

Full CLI test suite: 23 passed, 1 skipped.
