### PR TITLE
Carry rounded transcript timestamps

### DIFF
--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -120,11 +120,10 @@ class _TextBasedFormatter(TextFormatter):
         >>> self._seconds_to_timestamp(6.93)
         '00:00:06.930'
         """
-        time = float(time)
-        hours_float, remainder = divmod(time, 3600)
-        mins_float, secs_float = divmod(remainder, 60)
-        hours, mins, secs = int(hours_float), int(mins_float), int(secs_float)
-        ms = int(round((time - int(time)) * 1000, 2))
+        milliseconds = round(float(time) * 1000)
+        total_secs, ms = divmod(milliseconds, 1000)
+        total_mins, secs = divmod(total_secs, 60)
+        hours, mins = divmod(total_mins, 60)
         return self._format_timestamp(hours, mins, secs, ms)
 
     def format_transcript(self, transcript: FetchedTranscript, **kwargs) -> str:

--- a/youtube_transcript_api/test/test_formatters.py
+++ b/youtube_transcript_api/test/test_formatters.py
@@ -52,6 +52,24 @@ class TestFormatters(TestCase):
         self.assertEqual(lines[0], "1")
         self.assertEqual(lines[1], "00:00:00,000 --> 00:00:01,500")
 
+    def test_srt_formatter_carries_rounded_milliseconds(self):
+        transcript = FetchedTranscript(
+            snippets=[
+                FetchedTranscriptSnippet(
+                    text="Rounded boundary", start=1.9996, duration=1.0
+                ),
+            ],
+            language="English",
+            language_code="en",
+            is_generated=True,
+            video_id="12345",
+        )
+
+        content = SRTFormatter().format_transcript(transcript)
+        lines = content.split("\n")
+
+        self.assertEqual(lines[1], "00:00:02,000 --> 00:00:03,000")
+
     def test_srt_formatter_middle(self):
         content = SRTFormatter().format_transcript(self.transcript)
         lines = content.split("\n")


### PR DESCRIPTION
## What changed

`_seconds_to_timestamp()` now rounds the whole timestamp to milliseconds first, then splits that total into hours, minutes, seconds, and milliseconds.

## Why

The previous implementation truncated the seconds component before rounding the fractional milliseconds. Values near a second boundary, such as `1.9996`, formatted as `00:00:01,999` instead of carrying to `00:00:02,000`. The same helper is used by SRT and WebVTT formatting.

## Validation

- `python -m pytest youtube_transcript_api\test\test_formatters.py -q`
- `python -m pytest youtube_transcript_api -q`
- `python -m ruff check youtube_transcript_api\formatters.py youtube_transcript_api\test\test_formatters.py`
- `python -m ruff format --check youtube_transcript_api\formatters.py youtube_transcript_api\test\test_formatters.py`
- `git diff --check`